### PR TITLE
chore: avoid `latest` image tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
   # Prometheus scraper
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.2.1
     ports:
       - "9098:9090"
     volumes:
@@ -25,7 +25,7 @@ services:
 
   # Loki for logs
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:3.4.2
     ports:
       - "3108:3100"
     command: -config.file=/etc/loki/config.yml


### PR DESCRIPTION
## What does this do?

This PR ensures that we specify versions and avoid `latest`, to avoid some common pitfalls associated with this pattern.